### PR TITLE
Fix the wording about using context<>() in an state entry/exit action

### DIFF
--- a/Chapter-9/Readme.md
+++ b/Chapter-9/Readme.md
@@ -56,5 +56,5 @@ int main() {
 }
 ```
 
-- NOTE : _The context<>() can't be used inside the constructor / destructors of the state_ 
+- NOTE : _The context<>() and some other functions can't be used inside the constructor of the state derived from the simple_state<> template. If an entry action needs to access the "outside world", the state must derive from state<> instead and must implement appropriate forwarding constructor_. 
 


### PR DESCRIPTION
The restriction noted applies only to constructor (but not to destructor) of state based on `simple_state`. [The official tutorial](https://www.boost.org/doc/libs/1_72_0/libs/statechart/doc/tutorial.html) says:

>As soon as an entry action of a state needs to contact the "outside world" ..., the state must derive from state<> rather than from simple_state<> and must implement a forwarding constructor ... (apart from the constructor, state<> offers the same interface as simple_state<>).

The tutorial contains also the following code:
```
struct Running : sc::simple_state< Running, Active >
{
  public:
    typedef sc::transition< EvStartStop, Stopped > reactions;

    Running() : startTime_( std::time( 0 ) ) {}
    ~Running()
    {
      // ...
      context< Active >().ElapsedTime() +=
        std::difftime( std::time( 0 ), startTime_ );
    }
  private:
    std::time_t startTime_;
};
```